### PR TITLE
fix:EnableOverridingThemeColor

### DIFF
--- a/gatsby-theme-mate/gatsby-config.js
+++ b/gatsby-theme-mate/gatsby-config.js
@@ -27,7 +27,7 @@ module.exports = ({
           short_name: 'Mate',
           start_url: landingPath,
           background_color: colors.background,
-          theme_color: colors.primary,
+          theme_color_in_head: false,
           display: 'minimal-ui',
           icon: 'icon.png',
         },


### PR DESCRIPTION
This change enables to change theme-color with ReactHelmet that's currently introduced to this theme.

Without this gatsby-plugin-manifest inserts a theme-color meta tag into the site head. This means that you can't use React Helmet to set the theme_color.

**References**
https://github.com/gatsbyjs/gatsby/issues/9977
https://www.gatsbyjs.com/plugins/gatsby-plugin-manifest/#remove-theme-color-meta-tag