### PR TITLE
Replace Google Fonts

### DIFF
--- a/gatsby-theme-mate/src/styles/global.css
+++ b/gatsby-theme-mate/src/styles/global.css
@@ -1,2 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Cabin:wght@400;600&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+@import url('https://api.fonts.coollabs.io/css2?family=Cabin:wght@400;600&display=swap');
+@import url('https://api.fonts.coollabs.io/css2?family=Open+Sans&display=swap');
+ 


### PR DESCRIPTION
Replacing google fonts with Coollabs fonts due to it being more Privacy friendly and reducing bundle size